### PR TITLE
Refactor: Switch chatbot to Venice AI API and models

### DIFF
--- a/final.py
+++ b/final.py
@@ -3,10 +3,33 @@ from openai import OpenAI
 import tiktoken
 import streamlit as st
 
-api_key = st.secrets["OPENAI_API_KEY"] or os.getenv("OPENAI_API_KEY")
 
-client = OpenAI(api_key=api_key)
-MODEL = "gpt-4.1-nano-2025-04-14"
+def _secret(key: str):
+    try:
+        return st.secrets[key]
+    except Exception:
+        return None
+
+# Prefer VENICE_API_KEY, fall back to OPENAI_API_KEY for compatibility
+api_key = (
+    _secret("VENICE_API_KEY")
+    or os.getenv("VENICE_API_KEY")
+    or _secret("OPENAI_API_KEY")
+    or os.getenv("OPENAI_API_KEY")
+)
+
+BASE_URL = (
+    _secret("VENICE_BASE_URL")
+    or os.getenv("VENICE_BASE_URL")
+    or "https://api.venice.ai/api/v1"
+)
+
+if not api_key:
+    st.error("Missing API key. Set VENICE_API_KEY (preferred) or OPENAI_API_KEY in Streamlit secrets or environment.")
+    st.stop()
+
+client = OpenAI(api_key=api_key, base_url=BASE_URL)
+MODEL = "llama-3.3-70b"
 TEMPERATURE = 0.7
 MAX_TOKENS = 100
 TOKEN_BUDGET = 1000
@@ -41,18 +64,24 @@ def enforce_token_budget(messages, budget=TOKEN_BUDGET):
         print(f"[token budget error]: {e}")
 
 
-def chat(user_input, temperature=TEMPERATURE, max_tokens=MAX_TOKENS):
+def chat(user_input, model, temperature=TEMPERATURE, max_tokens=MAX_TOKENS):
     messages = st.session_state.messages
     messages.append({"role": "user", "content": user_input})
 
     enforce_token_budget(messages)
 
+    venice_params = {
+        "include_venice_system_prompt": bool(include_venice_sys),
+        "enable_web_search": "on" if bool(use_web_search) else "off",
+    }
+
     with st.spinner("Thinking..."):
         response = client.chat.completions.create(
-            model=MODEL,
+            model=model,
             messages=messages,
             temperature=temperature,
-            max_tokens=max_tokens
+            max_tokens=max_tokens,
+            extra_body={"venice_parameters": venice_params},
         )
     reply = response.choices[0].message.content
     messages.append({"role": "assistant", "content": reply})
@@ -62,11 +91,17 @@ def chat(user_input, temperature=TEMPERATURE, max_tokens=MAX_TOKENS):
 
 st.title("Sassy Chatbot")
 st.sidebar.header("Options")
-st.sidebar.write("This is a demo of a sassy chatbot using OpenAI's API.")
+st.sidebar.write("This is a demo of a sassy chatbot using Venice AI's OpenAI-compatible API.")
+
+# Model + Venice options
+model_id = st.sidebar.text_input("Model ID", value=MODEL, help="Example: llama-3.3-70b, qwen2.5-coder-32b, etc.")
+include_venice_sys = st.sidebar.checkbox("Include Venice system prompt", value=False,
+    help="If enabled, Venice may prepend its own system instructions.")
+use_web_search = st.sidebar.checkbox("Enable Venice web search", value=False)
 
 max_tokens = st.sidebar.slider("Max Tokens", 1, 250, 100)
 temperature = st.sidebar.slider("Temperature", 0.0, 1.0, 0.7)
-system_message_type = st.sidebar.selectbox("System Message",("Sassy Assistant", "Angry Assistant", "Custom"))
+system_message_type = st.sidebar.selectbox("System Message", ("Sassy Assistant", "Angry Assistant", "Custom"))
 
 if system_message_type == "Sassy Assistant":
     SYSTEM_PROMPT = "You are a sassy assistant that is fed up with answering questions."
@@ -89,7 +124,7 @@ if st.sidebar.button("Reset Conversation"):
     st.success("Conversation reset.")
 
 if prompt := st.chat_input("What is up?"):
-    reply = chat(prompt, temperature=temperature, max_tokens=max_tokens)
+    reply = chat(prompt, model=model_id.strip() or MODEL, temperature=temperature, max_tokens=max_tokens)
 
 for message in st.session_state.messages[1:]:
     with st.chat_message(message["role"]):

--- a/starter_code.py
+++ b/starter_code.py
@@ -2,10 +2,11 @@ import os
 from openai import OpenAI
 import tiktoken
 
-api_key = os.getenv("OPENAI_API_KEY")
+api_key = os.getenv("VENICE_API_KEY") or os.getenv("OPENAI_API_KEY")
+base_url = os.getenv("VENICE_BASE_URL") or "https://api.venice.ai/api/v1"
 
-client = OpenAI(api_key=api_key)
-MODEL = "gpt-4.1-nano-2025-04-14"
+client = OpenAI(api_key=api_key, base_url=base_url)
+MODEL = "llama-3.3-70b"
 TEMPERATURE = 0.7
 MAX_TOKENS = 100
 TOKEN_BUDGET = 1000


### PR DESCRIPTION
Summary
- Migrated chatbot to Venice AI's OpenAI-compatible API
- Default model set to `llama-3.3-70b`
- Added sidebar controls for Venice-specific parameters
  - Model ID input
  - Include Venice system prompt (on/off)
  - Enable Venice web search (on/off)

Changes
- final.py
  - OpenAI SDK now configured with `base_url=https://api.venice.ai/api/v1`
  - Reads `VENICE_API_KEY` (preferred) or falls back to `OPENAI_API_KEY`
  - UI updates to select model and toggle Venice parameters
  - Sends `venice_parameters` via `extra_body` in chat completions
- starter_code.py
  - Minimal refactor to target Venice API and default model

Config
- Environment variables supported:
  - `VENICE_API_KEY` (preferred)
  - `VENICE_BASE_URL` (optional; defaults to https://api.venice.ai/api/v1)
  - Fallback: `OPENAI_API_KEY`

Testing
- Manual smoke test recommended:
  1) `pip install -r requirements.txt`
  2) Set `VENICE_API_KEY`
  3) `streamlit run final.py`
  4) Choose a Venice model (e.g., `llama-3.3-70b`)

Notes
- No PR template found in repo; following standard description format.

Co-authored-by: openhands <openhands@all-hands.dev>

@tolu-jnj can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7281ff522f8143258e02358a0c6facab)